### PR TITLE
Refactored entites log

### DIFF
--- a/src/objects/lock.py
+++ b/src/objects/lock.py
@@ -13,7 +13,7 @@ class LockType(Enum):
 
 class Lock:
     """ Represents a single Lock object """
-    
+
     def __init__(self, lock_type, transaction, variable):
         self.lock_type = lock_type
         self.transaction = transaction

--- a/src/objects/site.py
+++ b/src/objects/site.py
@@ -18,14 +18,17 @@ class Site:
 
     def __init__(self, site_id, time, logger):
         self.identifer = site_id
-        self.data_manager = DataManager()
         self.status = SiteStatus.UP
 
+        variables = {}
         # Load all variables
         for i in range(1, 21):
             if i % 2 == 0 or 1 + (i % 10) == site_id:
-                logger.log("Adding " + str(Variable(i)) + " at time "+ str(time))
-                self.data_manager.add_variable(time, Variable(i))
+                new_variable = Variable(time, i)
+                logger.log("Adding %s at time %s" % (new_variable.identifier, str(time)))
+                variables[new_variable.identifier] = new_variable
+        
+        self.data_manager = DataManager(variables)
 
     def dump(self):
         """ Dump the results of all commits values to stdout """

--- a/src/objects/transaction.py
+++ b/src/objects/transaction.py
@@ -28,6 +28,6 @@ class Transaction:
         self.transaction_type = transaction_type
         self.start_time = start_time
         self.end_time = None
-        self.state = TransactionState.RUNNING
+        self.state = TransactionState.WAITING
         # Wait time?
         # Buffer

--- a/src/objects/variable.py
+++ b/src/objects/variable.py
@@ -8,13 +8,24 @@ This module represents a variable as specified in the Homework
 class Variable:
     """ Maintains all things related to a variable """
 
-    def __init__(self, var_id):
+    def __init__(self, time, var_id):
         self.index = var_id
         self.identifier = "x%i" % self.index
         self.replicated = (var_id / 2 == 0)
         self.readable = True
         self.value = 10 * var_id
-        self.last_committed_value = self.value
+        self.written_values = {}
+        self.update_value(time, self.value)
 
     def __repr__(self):
         return "{ %s: %s }" % (self.identifier, self.value)
+
+    def update_value(self, time, new_value):
+        """ Update the current variable value """
+        self.value = new_value
+        self.written_values[time] = new_value
+
+    def get_last_committed_value(self):
+        """ Returns the last committed value from the log """
+        return self.written_values[sorted(self.written_values.keys(), \
+                                          reverse=True)[0]]

--- a/src/tests/test_transaction_manager.py
+++ b/src/tests/test_transaction_manager.py
@@ -141,12 +141,9 @@ class TransactionManagerTestCase(unittest.TestCase):
 
     def test_execute_write_transaction(self):
         """ Given a Write instruction, write transaction will be called """
-        # TODO: Re-write function once write function has been written
-
+        
         instruction = Instruction("W(T1,x3,33)")
-        result = self.transaction_manager.execute(instruction)
-
-        self.assertEquals(result, "Write the value of a Variable")
+        self.assertRaises(ValueError, self.transaction_manager.execute, instruction)
 
 @contextmanager
 def std_out():

--- a/src/transaction_manager.py
+++ b/src/transaction_manager.py
@@ -32,7 +32,7 @@ class TransactionManager:
             self.sites[site.identifer] = site
             self.site_to_variables_map[i] = site.data_manager.variables
 
-            for variable in site.data_manager.variables:
+            for variable in site.data_manager.variables.values():
                 if variable not in self.variables_to_site_map:
                     self.variables_to_site_map[variable.identifier] = []
 
@@ -143,6 +143,10 @@ class TransactionManager:
 
     def write(self, instruction):
         """ Write the value of a Variable """
+
+        if instruction.transaction_identifier not in self.transactions:
+            raise ValueError("Transaction %s was never started" % \
+                             instruction.transaction_identifier)
 
         #get the transaction identifier from the instruction
         transaction_ident = instruction.transaction_identifier


### PR DESCRIPTION
Here was the idea I was trying to explain on slack about how we would be able to modify entities and keep track of everything. 

For a simple example of how this works, take a look at the unit test `test_entries_maintains_values_per_transaction` found in `test_data_manager.py` it shows how it works